### PR TITLE
Fix app crash when adding a new Exam or Assignment

### DIFF
--- a/app/src/main/java/com/jagoancoding/planyoursemester/ui/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/jagoancoding/planyoursemester/ui/overview/OverviewFragment.kt
@@ -158,14 +158,19 @@ class OverviewFragment : Fragment(),
                     true
                 }
                 R.id.action_rm_subject -> {
-                    viewModel.subjectNames().observeOnce(Observer {
-                        val dialog = RemoveSubjectDialog().apply {
-                            listener = this@OverviewFragment
-                            subjectNames = it.toTypedArray()
+                    viewModel.subjectNames().observeOnce(Observer { names ->
+
+                        if (names.isNullOrEmpty()) {
+                            context?.showLongToast(R.string.no_subjects_found)
+                        } else {
+                            val dialog = RemoveSubjectDialog().apply {
+                                listener = this@OverviewFragment
+                                subjectNames = names.toTypedArray()
+                            }
+                            dialog.show(
+                                fragmentManager!!, "RemoveSubjectDialog"
+                            )
                         }
-                        dialog.show(
-                            fragmentManager!!, "RemoveSubjectDialog"
-                        )
                     })
                     true
                 }
@@ -184,18 +189,32 @@ class OverviewFragment : Fragment(),
 
         // Pass subject names first
         viewModel.subjectNames().observeOnce(Observer { subjectNames ->
-            val bundle = Bundle().apply {
-                putInt(AddPlanFragment.PLAN_ITEM_TYPE, position)
-                putLong(AddPlanFragment.MiNIMUM_DATE, AppRepository.minimumDate)
-                putLong(AddPlanFragment.MAXIMUM_DATE, AppRepository.maximumDate)
-                putStringArrayList(
-                    AddPlanFragment.SUBJECT_NAMES_COL,
-                    ArrayList<String>(subjectNames)
-                )
-            }
-            view?.findNavController()?.navigate(R.id.addPlanFragment, bundle)
-        })
 
+            // Check if more than 1 subject is registered when clicking Exam
+            // or Assignment
+            if (subjectNames.isNullOrEmpty() &&
+                (position == PlanItem.TYPE_EXAM || position == PlanItem.TYPE_HOMEWORK)
+            ) {
+                // Show an error message
+                context?.showLongToast(R.string.subjects_empty)
+            } else {
+                val bundle = Bundle().apply {
+                    putInt(AddPlanFragment.PLAN_ITEM_TYPE, position)
+                    putLong(
+                        AddPlanFragment.MiNIMUM_DATE, AppRepository.minimumDate
+                    )
+                    putLong(
+                        AddPlanFragment.MAXIMUM_DATE, AppRepository.maximumDate
+                    )
+                    putStringArrayList(
+                        AddPlanFragment.SUBJECT_NAMES_COL,
+                        ArrayList<String>(subjectNames)
+                    )
+                }
+                view?.findNavController()
+                    ?.navigate(R.id.addPlanFragment, bundle)
+            }
+        })
     }
 
     override fun onRFACItemLabelClick(

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -57,4 +57,6 @@
     <string name="dialog_confirm_rm_subj_mes">Anda yakin ingin menghapus mapel \'%1$s\'?</string>
     <string name="success_subj_rm">"Mapel '%1$s' sukses dihapus "</string>
     <string name="fail_subj_rm">Harap hapus semua ujian atau tugas dari mapel \'%1$s\' terlebih dahulu</string>
+    <string name="no_subjects_found">Tidak ada mapel yang terdaftar!</string>
+    <string name="subjects_empty">Setidaknya 1 mapel harus terdaftar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,4 +64,6 @@
     <string name="dialog_confirm_rm_subj_mes">Do you really want to remove subject \'%1$s\'?</string>
     <string name="success_subj_rm">\'%1$s\' subject removed successfully</string>
     <string name="fail_subj_rm">Please remove all exams or homework of \'%1$s\' subject first</string>
+    <string name="no_subjects_found">No subjects found!</string>
+    <string name="subjects_empty">At least 1 subject must be registered</string>
 </resources>


### PR DESCRIPTION
Closes #11 . This PR prevents an app crash when trying to add an Exam with no `Subject` registered, and improves the error message when clicking on *Remove Subject* with no `Subject` registered.